### PR TITLE
Drop nil values in merging hash

### DIFF
--- a/lib/arc-furnace/merging_hash.rb
+++ b/lib/arc-furnace/merging_hash.rb
@@ -19,12 +19,10 @@ module ArcFurnace
                 new_row_entry.concat(Array.wrap(values))
                 row_entry[column] = new_row_entry
               end
-            elsif values.nil?
-              unless column.nil?
-                row_entry[column] = values
-              end
             else
-              row_entry[column] = values.dup
+              unless values.nil?
+                row_entry[column] = values.dup
+              end
             end
           end
         end

--- a/lib/arc-furnace/merging_hash.rb
+++ b/lib/arc-furnace/merging_hash.rb
@@ -19,6 +19,10 @@ module ArcFurnace
                 new_row_entry.concat(Array.wrap(values))
                 row_entry[column] = new_row_entry
               end
+            elsif values.nil?
+              unless column.nil?
+                row_entry[column] = values
+              end
             else
               row_entry[column] = values.dup
             end

--- a/spec/arc-furnace/merging_hash_spec.rb
+++ b/spec/arc-furnace/merging_hash_spec.rb
@@ -43,6 +43,18 @@ describe ArcFurnace::MergingHash do
         })
       end
     end
+
+    context 'with nil row values' do
+      let(:row3) { {"id" => "333", "Field 1" => "foo", "Field 2" => nil }.deep_freeze }
+      let(:source) { TestSource.new([row1, row2, row3])}
+
+      it 'drops all nil vlaues' do
+        expect(hash.get("333")).to eq ({
+          "id" => "333",
+          "Field 1" => "foo"
+        })
+      end
+    end
   end
 
 end


### PR DESCRIPTION
In Merge hash a column with an empty value would crash trying to dup the nil value, this now skips nil value cases.
It also prevents nil=> nil being added to the hash. 
