### PR TITLE
Remove extra prepare statement

### DIFF
--- a/lib/arc-furnace/inner_join.rb
+++ b/lib/arc-furnace/inner_join.rb
@@ -15,8 +15,6 @@ module ArcFurnace
     end
 
     def prepare
-      hash.prepare
-      source.prepare
       advance
     end
 

--- a/lib/arc-furnace/outer_join.rb
+++ b/lib/arc-furnace/outer_join.rb
@@ -15,15 +15,12 @@ module ArcFurnace
     end
 
     def prepare
-      hash.prepare
-      source.prepare
       advance
     end
 
     def advance
       loop do
-        @value = source.value
-        source.advance
+        @value = source.row
         break if value.nil?
 
         if hash_value = hash.get(value[hash.key_column])

--- a/lib/arc-furnace/outer_join.rb
+++ b/lib/arc-furnace/outer_join.rb
@@ -32,11 +32,8 @@ module ArcFurnace
             hash_value[key] = value
           end
           @value = hash_value
-          break
-        else
-          @value
-          break
         end
+        break
       end
     end
 

--- a/spec/arc-furnace/inner_join_spec.rb
+++ b/spec/arc-furnace/inner_join_spec.rb
@@ -20,7 +20,7 @@ describe ArcFurnace::InnerJoin do
 
     context 'with empty source hash' do
       let(:hash) { ArcFurnace::Hash.new(source: empty_source, key_column: "id" ) }
-      let(:source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: hash) }
+      let(:source) { ArcFurnace::InnerJoin.new(source: subsource2, hash: hash) }
 
       it 'returns original source' do
         expect(source.row).to eq nil

--- a/spec/arc-furnace/inner_join_spec.rb
+++ b/spec/arc-furnace/inner_join_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe ArcFurnace::InnerJoin do
   let(:subsource1) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/source1.csv") }
   let(:subsource2) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/source2.csv") }
+  let(:empty_source) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/empty_source.csv")}
   let(:hash) { ArcFurnace::Hash.new(source: subsource1, key_column: "id") }
   let(:source) { ArcFurnace::InnerJoin.new(source: subsource2, hash: hash) }
   before do
+    hash.prepare
     source.prepare
   end
 
@@ -14,6 +16,15 @@ describe ArcFurnace::InnerJoin do
       expect(source.row.to_hash).to eq ({ "id" => "111", "Field 1" => "boo bar", "Field 2" => "baz, bar", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
       expect(source.row.to_hash).to eq ({ "id" => "222", "Field 1" => "baz", "Field 2" => "boo bar", "Field 3" => "baz", "Field 4" => "boo bar" })
       expect(source.row).to be_nil
+    end
+
+    context 'with empty source hash' do
+      let(:hash) { ArcFurnace::Hash.new(source: empty_source, key_column: "id" ) }
+      let(:source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: hash) }
+
+      it 'returns original source' do
+        expect(source.row).to eq nil
+      end
     end
   end
 

--- a/spec/arc-furnace/outer_join_spec.rb
+++ b/spec/arc-furnace/outer_join_spec.rb
@@ -5,25 +5,28 @@ describe ArcFurnace::OuterJoin do
   let(:subsource2) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/source2.csv") }
   let(:empty_source) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/empty_source.csv")}
   let(:hash) { ArcFurnace::Hash.new(source: subsource1, key_column: "id") }
-  let(:empty_hash) { ArcFurnace::Hash.new(source: empty_source, key_column: "id" ) }
   let(:source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: hash) }
-  let(:empty_hash_join_source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: empty_hash) }
+
   before do
+    hash.prepare
     source.prepare
   end
 
   describe '#row' do
     it 'returns the current row and advances to the next row' do
-      expect(source.row.to_hash).to eq ({ "id" => "111", "Field 1" => "boo bar", "Field 2" => "baz, bar", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
-      expect(source.row.to_hash).to eq ({ "id" => "222", "Field 1" => "baz", "Field 2" => "boo bar", "Field 3" => "baz", "Field 4" => "boo bar" })
-      expect(source.row.to_hash).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
+      expect(source.row).to eq ({ "id" => "111", "Field 1" => "boo bar", "Field 2" => "baz, bar", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
+      expect(source.row).to eq ({ "id" => "222", "Field 1" => "baz", "Field 2" => "boo bar", "Field 3" => "baz", "Field 4" => "boo bar" })
+      expect(source.row).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
     end
 
     context 'with empty source hash' do
+      let(:hash) { ArcFurnace::Hash.new(source: empty_source, key_column: "id" ) }
+      let(:source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: hash) }
+
       it 'returns original source' do
-        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "111", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
-        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "222", "Field 3" => "baz", "Field 4" => "boo bar" })
-        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
+        expect(source.row).to eq ({ "id" => "111", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
+        expect(source.row).to eq ({ "id" => "222", "Field 3" => "baz", "Field 4" => "boo bar" })
+        expect(source.row).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
       end
     end
   end

--- a/spec/arc-furnace/outer_join_spec.rb
+++ b/spec/arc-furnace/outer_join_spec.rb
@@ -3,26 +3,38 @@ require 'spec_helper'
 describe ArcFurnace::OuterJoin do
   let(:subsource1) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/source1.csv") }
   let(:subsource2) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/source2.csv") }
+  let(:empty_source) { ArcFurnace::CSVSource.new(filename: "#{ArcFurnace.test_root}/resources/empty_source.csv")}
   let(:hash) { ArcFurnace::Hash.new(source: subsource1, key_column: "id") }
+  let(:empty_hash) { ArcFurnace::Hash.new(source: empty_source, key_column: "id" ) }
   let(:source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: hash) }
+  let(:empty_hash_join_source) { ArcFurnace::OuterJoin.new(source: subsource2, hash: empty_hash) }
   before do
     source.prepare
   end
 
   describe '#row' do
-    it 'feeds all rows' do
+    it 'returns the current row and advances to the next row' do
       expect(source.row.to_hash).to eq ({ "id" => "111", "Field 1" => "boo bar", "Field 2" => "baz, bar", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
       expect(source.row.to_hash).to eq ({ "id" => "222", "Field 1" => "baz", "Field 2" => "boo bar", "Field 3" => "baz", "Field 4" => "boo bar" })
       expect(source.row.to_hash).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
     end
+
+    context 'with empty source hash' do
+      it 'returns original source' do
+        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "111", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
+        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "222", "Field 3" => "baz", "Field 4" => "boo bar" })
+        expect(empty_hash_join_source.row.to_hash).to eq ({ "id" => "333", "Field 3" => "black", "Field 4" => "brown" })
+      end
+    end
   end
 
   describe '#value' do
-    it 'feeds all rows' do
+    it 'returns the current row' do
       expect(source.value.to_hash).to eq ({ "id" => "111", "Field 1" => "boo bar", "Field 2" => "baz, bar", "Field 3" => "boo bar", "Field 4" => "baz, bar" })
       second_row = { "id" => "222", "Field 1" => "baz", "Field 2" => "boo bar", "Field 3" => "baz", "Field 4" => "boo bar" }
       third_row = { "id" => "333", "Field 3" => "black", "Field 4" => "brown" }
       source.advance
+      expect(source.value.to_hash).to eq second_row
       expect(source.value.to_hash).to eq second_row
       expect(source.row.to_hash).to eq second_row
       expect(source.value.to_hash).to eq third_row


### PR DESCRIPTION
Get rid of extra prepare statement to prevent dropping rows during joins.
Add specs for inner and outer joins with nil hashes. 