### PR TITLE
Source error handling new

### DIFF
--- a/lib/arc-furnace/pipeline.rb
+++ b/lib/arc-furnace/pipeline.rb
@@ -151,9 +151,9 @@ module ArcFurnace
 
       def build
         dsl_class.intermediates_map.each do |key, instance|
-          intermediates_map[key] = instance_exec(&instance) if instance
+          intermediates_map[key] = exec_with_error_handling(&instance) if instance
         end
-        @sink_node = exec_with_error_handling(&dsl_class.sink_node)
+        @sink_node = instance_exec(&dsl_class.sink_node)
         @sink_source = intermediates_map[dsl_class.sink_source]
       end
 
@@ -176,7 +176,7 @@ module ArcFurnace
       end
 
       def exec_with_error_handling(&block)
-        instance_exec(&block) if block_given?
+        instance_exec(&block)
       rescue CSV::MalformedCSVError
         params = sink_source.params
         raise "File #{find_root_source(params).file.path} cannot be processed."

--- a/lib/arc-furnace/pipeline.rb
+++ b/lib/arc-furnace/pipeline.rb
@@ -108,7 +108,7 @@ module ArcFurnace
           ALLOWABLE_PARAM_TYPES.include?(param.first)
         end.map(&:second)
         # Allow params to be passed that are not in the initializer
-        instance = type.new(resolved_params.slice(*key_parameters))
+        instance = create_instance_with_error_handling(type, resolved_params, key_parameters)
         instance.params = resolved_params
         instance
       end
@@ -151,7 +151,7 @@ module ArcFurnace
 
       def build
         dsl_class.intermediates_map.each do |key, instance|
-          intermediates_map[key] = exec_with_error_handling(&instance) if instance
+          intermediates_map[key] = instance_exec(&instance) if instance
         end
         @sink_node = instance_exec(&dsl_class.sink_node)
         @sink_source = intermediates_map[dsl_class.sink_source]
@@ -175,16 +175,10 @@ module ArcFurnace
         self.params[key] || self.intermediates_map[key] || (raise "When processing node #{node_id}: Unknown key #{key}!")
       end
 
-      def exec_with_error_handling(&block)
-        instance_exec(&block)
+      def create_instance_with_error_handling(type, resolved_params, key_parameters)
+        type.new(resolved_params.slice(*key_parameters))
       rescue CSV::MalformedCSVError
-        params = sink_source.params
-        raise "File #{find_root_source(params).file.path} cannot be processed."
-      end
-
-      def find_root_source(params)
-        source = params[:source]
-        source = params[:source] while source.params[:source]
+        raise "File #{resolved_params[:filename]} cannot be processed."
       end
     end
   end


### PR DESCRIPTION
It works now. I realized the problem was within the proc. The unshift/pop action, where the error is originally raised, occurs when the instance of the given class is created and that class is a csvsource/multicsvsource