### PR TITLE
Roo Syntax Bug

### DIFF
--- a/lib/arc-furnace/excel_source.rb
+++ b/lib/arc-furnace/excel_source.rb
@@ -25,7 +25,7 @@ module ArcFurnace
 
     def extract_cell_value(cell)
       if cell
-        coerced_value = cell.type == :string ? cell.value : cell.excelx_value.try(:to_s).try(:strip)
+        coerced_value = cell.type == :string ? cell.value : cell.cell_value.try(:to_s).try(:strip)
         coerced_value unless coerced_value.blank?
       end
     end

--- a/lib/arc-furnace/multi_excel_source.rb
+++ b/lib/arc-furnace/multi_excel_source.rb
@@ -60,7 +60,7 @@ module ArcFurnace
 
     def extract_cell_value(cell)
       if cell
-        coerced_value = cell.type == :string ? cell.value : cell.excelx_value.try(:to_s).try(:strip)
+        coerced_value = cell.type == :string ? cell.value : cell.cell_value.try(:to_s).try(:strip)
         coerced_value unless coerced_value.blank?
       end
     end


### PR DESCRIPTION
Roo pops up [DEPRECATION] `excelx_value` is deprecated.  Please use `cell_value` instead. when using any of the Excel-based sources. Under the hood that method is just:

```
        def excelx_value
          warn '[DEPRECATION] `excelx_value` is deprecated.  Please use `cell_value` instead.'
          cell_value
        end
```